### PR TITLE
fix: store.save() をバックグラウンドスレッドで実行する

### DIFF
--- a/pipeline/src/main/java/com/example/wearos/pipeline/SensorPipeline.kt
+++ b/pipeline/src/main/java/com/example/wearos/pipeline/SensorPipeline.kt
@@ -6,13 +6,14 @@ import java.util.concurrent.Executors
 
 class SensorPipeline(private val config: SensorPipelineConfig) {
 
+    private val ioExecutor = Executors.newSingleThreadExecutor()
     private val sendExecutor = Executors.newSingleThreadExecutor()
 
     fun start() {
         val listener = object : SensorCollectorListener {
             override fun onSensorData(data: SensorData) {
                 val serialized = config.serializer.serialize(data)
-                config.store?.save(serialized)
+                ioExecutor.execute { config.store?.save(serialized) }
                 sendExecutor.execute { config.sender?.send(serialized) }
             }
         }
@@ -21,6 +22,7 @@ class SensorPipeline(private val config: SensorPipelineConfig) {
 
     fun stop() {
         config.collectors.forEach { it.stop() }
+        ioExecutor.shutdown()
         sendExecutor.shutdown()
     }
 }


### PR DESCRIPTION
## 問題

`SensorPipeline` の `onSensorData()` は `onSensorChanged()` のセンサースレッド上で呼ばれる。
現在 `store.save()` はそのスレッドで同期実行されており、ファイル I/O がセンサーイベントの受信をブロックする可能性がある。

```kotlin
// pipeline/src/main/java/com/example/wearos/pipeline/SensorPipeline.kt
override fun onSensorData(data: SensorData) {
    val serialized = config.serializer.serialize(data)
    config.store?.save(serialized)                            // ← センサースレッドで同期実行（問題）
    sendExecutor.execute { config.sender?.send(serialized) } // ← こちらはバックグラウンド済み
}
```

## 修正方針

`store.save()` も executor でバックグラウンド実行する。
store と sender は順序依存がないため、同じ executor に乗せるか別々にするかどちらでもよい。

```kotlin
// 案1: 同じ executor にまとめる
sendExecutor.execute {
    config.store?.save(serialized)
    config.sender?.send(serialized)
}

// 案2: store 用に別 executor を用意する（store と sender を並列実行）
private val ioExecutor = Executors.newSingleThreadExecutor()

ioExecutor.execute { config.store?.save(serialized) }
sendExecutor.execute { config.sender?.send(serialized) }
```

`stop()` では使用しているすべての executor を `shutdown()` すること。

## 対象ファイル

- `pipeline/src/main/java/com/example/wearos/pipeline/SensorPipeline.kt`