### PR TITLE
feat: FirestoreStore を追加

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -117,7 +117,7 @@ pipeline = SensorPipeline(
 )
 ```
 
-### 保存だけ（送信しない）
+### ローカルファイルに保存する（送信しない）
 
 ```kotlin
 SensorPipelineConfig(
@@ -126,6 +126,60 @@ SensorPipelineConfig(
     // sender を省略 → 送信スキップ
 )
 ```
+
+### Cloud Firestore に保存する
+
+#### 事前準備（利用側アプリ）
+
+1. [Firebase Console](https://console.firebase.google.com/) でプロジェクトを作成し、`google-services.json` をアプリモジュールに配置する
+2. アプリの `build.gradle.kts` に Google Services プラグインを追加する:
+
+```kotlin
+// app/build.gradle.kts
+plugins {
+    id("com.google.gms.google-services")
+}
+```
+
+3. ルートの `build.gradle.kts` にもプラグインを追加する:
+
+```kotlin
+// build.gradle.kts (root)
+plugins {
+    id("com.google.gms.google-services") version "4.4.0" apply false
+}
+```
+
+#### 使い方
+
+```kotlin
+SensorPipelineConfig(
+    collectors = listOf(
+        AccelerometerCollector(this),
+        HeartRateCollector(this)
+    ),
+    store = FirestoreStore(collection = "sensor_data")
+)
+```
+
+コレクション名は省略可能（デフォルト: `"sensor_data"`）。
+
+#### Firestore のドキュメント構造
+
+```
+sensor_data/
+  {auto-id}/
+    type:             "accelerometer"
+    values:           [0.12, -9.80, 0.05]
+    timestamp_ns:     123456789
+    server_timestamp: <サーバータイムスタンプ>
+```
+
+#### 注意事項
+
+- `readAll()` / `clear()` は Firestore の非同期 API の性質上サポートしていません（呼ぶと `UnsupportedOperationException`）
+- データの参照・削除は Firebase Console または Admin SDK を使ってください
+- Firestore のセキュリティルールは Firebase Console で設定してください
 
 ### 独自のシリアライザーに差し替える
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ tiles-material = "1.1.0"
 horologist-compose-tools = "0.1.5"
 horologist-tiles = "0.1.5"
 watchface-complications-data-source-ktx = "1.1.1"
+firebase-bom = "32.7.0"
 
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
@@ -38,6 +39,8 @@ tiles-material = { group = "androidx.wear.tiles", name = "tiles-material", versi
 horologist-compose-tools = { group = "com.google.android.horologist", name = "horologist-compose-tools", version.ref = "horologist-compose-tools" }
 horologist-tiles = { group = "com.google.android.horologist", name = "horologist-tiles", version.ref = "horologist-tiles" }
 watchface-complications-data-source-ktx = { group = "androidx.wear.watchface", name = "watchface-complications-data-source-ktx", version.ref = "watchface-complications-data-source-ktx" }
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
+firebase-firestore-ktx = { group = "com.google.firebase", name = "firebase-firestore-ktx" }
 
 [plugins]
 com-android-application = { id = "com.android.application", version.ref = "agp" }

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -24,6 +24,6 @@ android {
 dependencies {
     implementation(libs.core.ktx)
     implementation(project(":sensing"))
-    implementation(platform(libs.firebase.bom))
-    implementation(libs.firebase.firestore.ktx)
+    api(platform(libs.firebase.bom))
+    api(libs.firebase.firestore.ktx)
 }

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -24,4 +24,6 @@ android {
 dependencies {
     implementation(libs.core.ktx)
     implementation(project(":sensing"))
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.firestore.ktx)
 }

--- a/storage/src/main/java/com/example/wearos/storage/FirestoreStore.kt
+++ b/storage/src/main/java/com/example/wearos/storage/FirestoreStore.kt
@@ -3,6 +3,7 @@ package com.example.wearos.storage
 import android.util.Log
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.WriteBatch
 import org.json.JSONObject
 
 /**
@@ -16,18 +17,40 @@ import org.json.JSONObject
  * ```
  * {collection}/
  *   {auto-id}/
- *     type:           "accelerometer"
- *     values:         [0.12, -9.80, 0.05]
- *     timestamp_ns:   123456789
+ *     type:             "accelerometer"
+ *     values:           [0.12, -9.80, 0.05]
+ *     timestamp_ns:     123456789
  *     server_timestamp: <Firestore サーバータイムスタンプ>
  * ```
+ *
+ * @param collection 保存先の Firestore コレクション名（デフォルト: "sensor_data"）
+ * @param batchSize  この件数ごとに WriteBatch でまとめて書き込む（デフォルト: 20）。
+ *                   高頻度センサー（SENSOR_DELAY_GAME）では 1 イベント = 1 書き込みだと
+ *                   Firestore クォータを大量消費するため、まとめて書き込むことを推奨する。
+ *                   [stop] を呼ぶと未送信のバッファも強制フラッシュされる。
  *
  * **注意:** [readAll] と [clear] は Firestore の非同期 API の性質上サポートしていない。
  */
 class FirestoreStore(
     private val collection: String = "sensor_data",
-    private val db: FirebaseFirestore = FirebaseFirestore.getInstance()
+    private val batchSize: Int = 20
 ) : SensorDataStore {
+
+    private val db: FirebaseFirestore = FirebaseFirestore.getInstance()
+
+    /** テスト用: FirebaseFirestore を差し替えられる internal コンストラクタ */
+    internal constructor(
+        collection: String,
+        batchSize: Int,
+        db: FirebaseFirestore
+    ) : this(collection, batchSize) {
+        _db = db
+    }
+
+    private var _db: FirebaseFirestore? = null
+    private val firestore get() = _db ?: db
+
+    private val buffer = mutableListOf<Map<String, Any>>()
 
     override fun save(serialized: String) {
         try {
@@ -35,27 +58,43 @@ class FirestoreStore(
             val valuesArray = json.getJSONArray("values")
             val values = (0 until valuesArray.length()).map { valuesArray.getDouble(it) }
 
-            val document = hashMapOf(
+            val document = mapOf(
                 "type"             to json.getString("type"),
                 "values"           to values,
                 "timestamp_ns"     to json.getLong("timestamp_ns"),
                 "server_timestamp" to FieldValue.serverTimestamp()
             )
 
-            db.collection(collection)
-                .add(document)
-                .addOnFailureListener { e ->
-                    Log.e("FirestoreStore", "Failed to save document: $e")
-                }
+            synchronized(buffer) {
+                buffer.add(document)
+                if (buffer.size >= batchSize) flush()
+            }
         } catch (e: Exception) {
-            Log.e("FirestoreStore", "Failed to parse or save: $e")
+            Log.e("FirestoreStore", "Failed to parse sensor data: ${e.message}", e)
+        }
+    }
+
+    /** センシング停止時に呼ぶ。バッファに残った未送信データを強制フラッシュする。 */
+    fun stop() {
+        synchronized(buffer) { flush() }
+    }
+
+    private fun flush() {
+        if (buffer.isEmpty()) return
+        val batch: WriteBatch = firestore.batch()
+        buffer.forEach { doc ->
+            batch.set(firestore.collection(collection).document(), doc)
+        }
+        buffer.clear()
+        batch.commit().addOnFailureListener { e ->
+            Log.e("FirestoreStore", "Failed to commit batch: ${e.message}", e)
         }
     }
 
     override fun readAll(): List<String> {
         throw UnsupportedOperationException(
             "FirestoreStore does not support synchronous readAll(). " +
-            "Use FirebaseFirestore.getInstance().collection(\"$collection\").get() directly."
+            "Use the configured Firestore instance to read from collection \"$collection\" asynchronously."
         )
     }
 

--- a/storage/src/main/java/com/example/wearos/storage/FirestoreStore.kt
+++ b/storage/src/main/java/com/example/wearos/storage/FirestoreStore.kt
@@ -1,0 +1,68 @@
+package com.example.wearos.storage
+
+import android.util.Log
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import org.json.JSONObject
+
+/**
+ * SensorData を Cloud Firestore に保存する SensorDataStore 実装。
+ *
+ * **前提条件（利用側アプリ）:**
+ * - `google-services.json` をアプリモジュールに配置すること
+ * - アプリの `build.gradle.kts` に `com.google.gms.google-services` プラグインを適用すること
+ *
+ * **Firestore のドキュメント構造:**
+ * ```
+ * {collection}/
+ *   {auto-id}/
+ *     type:           "accelerometer"
+ *     values:         [0.12, -9.80, 0.05]
+ *     timestamp_ns:   123456789
+ *     server_timestamp: <Firestore サーバータイムスタンプ>
+ * ```
+ *
+ * **注意:** [readAll] と [clear] は Firestore の非同期 API の性質上サポートしていない。
+ */
+class FirestoreStore(
+    private val collection: String = "sensor_data",
+    private val db: FirebaseFirestore = FirebaseFirestore.getInstance()
+) : SensorDataStore {
+
+    override fun save(serialized: String) {
+        try {
+            val json = JSONObject(serialized)
+            val valuesArray = json.getJSONArray("values")
+            val values = (0 until valuesArray.length()).map { valuesArray.getDouble(it) }
+
+            val document = hashMapOf(
+                "type"             to json.getString("type"),
+                "values"           to values,
+                "timestamp_ns"     to json.getLong("timestamp_ns"),
+                "server_timestamp" to FieldValue.serverTimestamp()
+            )
+
+            db.collection(collection)
+                .add(document)
+                .addOnFailureListener { e ->
+                    Log.e("FirestoreStore", "Failed to save document: $e")
+                }
+        } catch (e: Exception) {
+            Log.e("FirestoreStore", "Failed to parse or save: $e")
+        }
+    }
+
+    override fun readAll(): List<String> {
+        throw UnsupportedOperationException(
+            "FirestoreStore does not support synchronous readAll(). " +
+            "Use FirebaseFirestore.getInstance().collection(\"$collection\").get() directly."
+        )
+    }
+
+    override fun clear() {
+        throw UnsupportedOperationException(
+            "FirestoreStore does not support clear(). " +
+            "Delete documents directly via the Firebase Console or Admin SDK."
+        )
+    }
+}


### PR DESCRIPTION
## 概要

`SensorDataStore` を実装した `FirestoreStore` を `storage` モジュールに追加する。
センサーデータを Cloud Firestore にリアルタイム保存できるようになる。

## 変更内容

### 新規ファイル
- `storage/src/main/java/com/example/wearos/storage/FirestoreStore.kt`

### 変更ファイル
- `gradle/libs.versions.toml` — Firebase BOM 32.7.0 と firestore-ktx を追加
- `storage/build.gradle.kts` — Firebase 依存を追加
- `docs/USAGE.md` — Firestore の使い方を追記

## Firestore ドキュメント構造

```
sensor_data/
  {auto-id}/
    type:             "accelerometer"
    values:           [0.12, -9.80, 0.05]
    timestamp_ns:     123456789
    server_timestamp: <サーバータイムスタンプ>
```

## 使い方

```kotlin
SensorPipelineConfig(
    collectors = listOf(AccelerometerCollector(this)),
    store = FirestoreStore(collection = "sensor_data")
)
```

## 注意事項

- 利用側アプリに `google-services.json` の配置と `com.google.gms.google-services` プラグインの適用が必要
- `readAll()` / `clear()` は非同期 API の性質上 `UnsupportedOperationException`
- `save()` は fire-and-forget（失敗時は `Log.e`）