### PR TITLE
refactor: シリアライザーと FirestoreStore のモジュール整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,8 @@ wearos/
 
 | ファイル | 役割 |
 |---------|------|
-| `SensorDataSerializer.kt` | シリアライズインターフェース |
-| `JsonSerializer.kt` | `SensorData` → JSON 文字列 |
 | `SensorDataStore.kt` | 永続化インターフェース |
 | `LocalFileStore.kt` | アプリ内ストレージへの JSONL 追記保存 |
-| `FirestoreStore.kt` | Cloud Firestore への保存（バッチ書き込み対応） |
 
 ### network
 
@@ -51,11 +48,15 @@ wearos/
 |---------|------|
 | `DataSender.kt` | 送信インターフェース |
 | `UdpSender.kt` | UDP 送信実装 |
+| `HttpSender.kt` | HTTP POST 送信実装 |
+| `FirestoreSender.kt` | Cloud Firestore 送信実装（バッチ書き込み対応） |
 
 ### pipeline
 
 | ファイル | 役割 |
 |---------|------|
+| `SensorDataSerializer.kt` | シリアライズインターフェース |
+| `JsonSerializer.kt` | `SensorData` → JSON 文字列 |
 | `SensorPipelineConfig.kt` | collectors / serializer / store / sender をまとめる設定 |
 | `SensorPipeline.kt` | `start()` / `stop()` でフロー全体を制御 |
 
@@ -169,12 +170,12 @@ SensorPipelineConfig(
 )
 ```
 
-### Cloud Firestore に保存する
+### Cloud Firestore に送信する
 
 ```kotlin
 SensorPipelineConfig(
     collectors = listOf(AccelerometerCollector(this)),
-    store = FirestoreStore(collection = "sensor_data", batchSize = 20)
+    sender = FirestoreSender(collection = "sensor_data", batchSize = 20)
 )
 ```
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -158,7 +158,7 @@ SensorPipelineConfig(
         AccelerometerCollector(this),
         HeartRateCollector(this)
     ),
-    store = FirestoreStore(collection = "sensor_data")
+    store = FirestoreSender(collection = "sensor_data")
 )
 ```
 

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -23,4 +23,6 @@ android {
 
 dependencies {
     implementation(libs.core.ktx)
+    api(platform(libs.firebase.bom))
+    api(libs.firebase.firestore.ktx)
 }

--- a/network/src/main/java/com/example/wearos/network/DataSender.kt
+++ b/network/src/main/java/com/example/wearos/network/DataSender.kt
@@ -2,4 +2,5 @@ package com.example.wearos.network
 
 interface DataSender {
     fun send(payload: String)
+    fun onStop() {}  // バッファを持つ実装がフラッシュ処理を行うためのライフサイクルフック
 }

--- a/network/src/main/java/com/example/wearos/network/FirestoreSender.kt
+++ b/network/src/main/java/com/example/wearos/network/FirestoreSender.kt
@@ -1,4 +1,4 @@
-package com.example.wearos.storage
+package com.example.wearos.network
 
 import android.util.Log
 import com.google.firebase.firestore.FieldValue
@@ -7,7 +7,7 @@ import com.google.firebase.firestore.WriteBatch
 import org.json.JSONObject
 
 /**
- * SensorData を Cloud Firestore に保存する SensorDataStore 実装。
+ * センサーデータを Cloud Firestore に送信する DataSender 実装。
  *
  * **前提条件（利用側アプリ）:**
  * - `google-services.json` をアプリモジュールに配置すること
@@ -23,18 +23,15 @@ import org.json.JSONObject
  *     server_timestamp: <Firestore サーバータイムスタンプ>
  * ```
  *
- * @param collection 保存先の Firestore コレクション名（デフォルト: "sensor_data"）
+ * @param collection 送信先の Firestore コレクション名（デフォルト: "sensor_data"）
  * @param batchSize  この件数ごとに WriteBatch でまとめて書き込む（デフォルト: 20）。
  *                   高頻度センサー（SENSOR_DELAY_GAME）では 1 イベント = 1 書き込みだと
  *                   Firestore クォータを大量消費するため、まとめて書き込むことを推奨する。
- *                   [stop] を呼ぶと未送信のバッファも強制フラッシュされる。
- *
- * **注意:** [readAll] と [clear] は Firestore の非同期 API の性質上サポートしていない。
  */
-class FirestoreStore(
+class FirestoreSender(
     private val collection: String = "sensor_data",
     private val batchSize: Int = 20
-) : SensorDataStore {
+) : DataSender {
 
     private val db: FirebaseFirestore = FirebaseFirestore.getInstance()
 
@@ -52,9 +49,9 @@ class FirestoreStore(
 
     private val buffer = mutableListOf<Map<String, Any>>()
 
-    override fun save(serialized: String) {
+    override fun send(payload: String) {
         try {
-            val json = JSONObject(serialized)
+            val json = JSONObject(payload)
             val valuesArray = json.getJSONArray("values")
             val values = (0 until valuesArray.length()).map { valuesArray.getDouble(it) }
 
@@ -70,12 +67,11 @@ class FirestoreStore(
                 if (buffer.size >= batchSize) flush()
             }
         } catch (e: Exception) {
-            Log.e("FirestoreStore", "Failed to parse sensor data: ${e.message}", e)
+            Log.e("FirestoreSender", "Failed to parse sensor data: ${e.message}", e)
         }
     }
 
-    /** センシング停止時に呼ぶ。バッファに残った未送信データを強制フラッシュする。 */
-    fun stop() {
+    override fun onStop() {
         synchronized(buffer) { flush() }
     }
 
@@ -87,21 +83,7 @@ class FirestoreStore(
         }
         buffer.clear()
         batch.commit().addOnFailureListener { e ->
-            Log.e("FirestoreStore", "Failed to commit batch: ${e.message}", e)
+            Log.e("FirestoreSender", "Failed to commit batch: ${e.message}", e)
         }
-    }
-
-    override fun readAll(): List<String> {
-        throw UnsupportedOperationException(
-            "FirestoreStore does not support synchronous readAll(). " +
-            "Use the configured Firestore instance to read from collection \"$collection\" asynchronously."
-        )
-    }
-
-    override fun clear() {
-        throw UnsupportedOperationException(
-            "FirestoreStore does not support clear(). " +
-            "Delete documents directly via the Firebase Console or Admin SDK."
-        )
     }
 }

--- a/pipeline/src/main/java/com/example/wearos/pipeline/JsonSerializer.kt
+++ b/pipeline/src/main/java/com/example/wearos/pipeline/JsonSerializer.kt
@@ -1,4 +1,4 @@
-package com.example.wearos.storage
+package com.example.wearos.pipeline
 
 import com.example.wearos.sensing.SensorData
 import org.json.JSONArray

--- a/pipeline/src/main/java/com/example/wearos/pipeline/SensorDataSerializer.kt
+++ b/pipeline/src/main/java/com/example/wearos/pipeline/SensorDataSerializer.kt
@@ -1,4 +1,4 @@
-package com.example.wearos.storage
+package com.example.wearos.pipeline
 
 import com.example.wearos.sensing.SensorData
 

--- a/pipeline/src/main/java/com/example/wearos/pipeline/SensorPipeline.kt
+++ b/pipeline/src/main/java/com/example/wearos/pipeline/SensorPipeline.kt
@@ -22,6 +22,7 @@ class SensorPipeline(private val config: SensorPipelineConfig) {
 
     fun stop() {
         config.collectors.forEach { it.stop() }
+        config.sender?.onStop()
         ioExecutor.shutdown()
         sendExecutor.shutdown()
     }

--- a/pipeline/src/main/java/com/example/wearos/pipeline/SensorPipelineConfig.kt
+++ b/pipeline/src/main/java/com/example/wearos/pipeline/SensorPipelineConfig.kt
@@ -2,8 +2,6 @@ package com.example.wearos.pipeline
 
 import com.example.wearos.network.DataSender
 import com.example.wearos.sensing.BaseSensorCollector
-import com.example.wearos.storage.JsonSerializer
-import com.example.wearos.storage.SensorDataSerializer
 import com.example.wearos.storage.SensorDataStore
 
 data class SensorPipelineConfig(

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -24,6 +24,5 @@ android {
 dependencies {
     implementation(libs.core.ktx)
     implementation(project(":sensing"))
-    api(platform(libs.firebase.bom))
-    api(libs.firebase.firestore.ktx)
+
 }


### PR DESCRIPTION
## 概要

モジュールの責務をより明確に分離するためのリファクタリング。

## 変更内容

### SensorDataSerializer / JsonSerializer を `storage` → `pipeline` へ移動

シリアライズは「パイプラインがデータをどう変換するか」の関心事であり、ストレージ固有の概念ではない。`SensorPipeline` 自身が呼び出している処理なので `pipeline` モジュールに置くのが自然。

### FirestoreStore を `storage` → `network` へ移動、`FirestoreSender` にリネーム

Firestore はリモートサービスへのネットワーク送信であり、ローカル永続化の `LocalFileStore` とは性質が異なる。`DataSender` を実装することで `UdpSender` / `HttpSender` と同じ感覚で使える。

```kotlin
// before
store = FirestoreStore(collection = "sensor_data")

// after
sender = FirestoreSender(collection = "sensor_data")
```

### DataSender に `onStop()` を追加

`FirestoreSender` はバッチ書き込みのためにバッファを持つ。`SensorPipeline.stop()` 時に未送信データをフラッシュするためのライフサイクルフック。`UdpSender` / `HttpSender` はデフォルト実装（no-op）のままで影響なし。

## モジュール責務（変更後）

| モジュール | 責務 |
|-----------|------|
| `sensing` | SensorData の取得 |
| `storage` | ローカル永続化のみ（SensorDataStore / LocalFileStore） |
| `network` | 外部への送信（UDP / HTTP / Firestore） |
| `pipeline` | 配線 + シリアライズ（SensorDataSerializer / JsonSerializer） |