### PR TITLE
feat: フェーズ2 新センサ追加（TODO ドキュメント）

### DIFF
--- a/docs/TODO/017-add-sensor-type-constants.md
+++ b/docs/TODO/017-add-sensor-type-constants.md
@@ -1,0 +1,42 @@
+# 017 SensorData に新センサの TYPE 定数を追加
+
+## 概要
+
+`SensorData.kt` の `companion object` に、新たに追加するすべてのセンサの型文字列定数を追加する。
+**このタスクを最初に完了させること。018〜029 はこの定数に依存する。**
+
+## 対象ファイル
+
+`sensing/src/main/java/com/example/wearos/sensing/SensorData.kt`
+
+## 変更内容
+
+`companion object` に以下の定数を追記する:
+
+```kotlin
+companion object {
+    // 既存
+    const val TYPE_ACCELEROMETER = "accelerometer"
+    const val TYPE_HEART_RATE    = "heart_rate"
+    const val TYPE_LIGHT         = "light"
+
+    // 追加
+    const val TYPE_GYROSCOPE             = "gyroscope"
+    const val TYPE_MAGNETIC_FIELD        = "magnetic_field"
+    const val TYPE_ROTATION_VECTOR       = "rotation_vector"
+    const val TYPE_STEP_COUNTER          = "step_counter"
+    const val TYPE_STEP_DETECTOR         = "step_detector"
+    const val TYPE_GRAVITY               = "gravity"
+    const val TYPE_LINEAR_ACCELERATION   = "linear_acceleration"
+    const val TYPE_PRESSURE              = "pressure"
+    const val TYPE_HEART_BEAT            = "heart_beat"
+    const val TYPE_OXYGEN_SATURATION     = "oxygen_saturation"
+    const val TYPE_SKIN_TEMPERATURE      = "skin_temperature"
+    const val TYPE_OFF_BODY_DETECT       = "off_body_detect"
+}
+```
+
+## 完了条件
+
+- 上記 12 定数が `SensorData.kt` に追加されている
+- ビルドが通ること

--- a/docs/TODO/018-implement-gyroscope-collector.md
+++ b/docs/TODO/018-implement-gyroscope-collector.md
@@ -1,0 +1,55 @@
+# 018 GyroscopeCollector の実装
+
+## 概要
+
+ジャイロスコープ（角速度）センサのコレクターを実装する。
+姿勢変化・回転動作の検出に使用する。
+
+## 前提
+
+- 017 完了済みであること（`SensorData.TYPE_GYROSCOPE` が存在する）
+
+## 対象ファイル
+
+新規作成: `sensing/src/main/java/com/example/wearos/sensing/GyroscopeCollector.kt`
+
+## 実装内容
+
+```kotlin
+package com.example.wearos.sensing
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorManager
+
+class GyroscopeCollector(
+    context: Context
+) : BaseSensorCollector(context) {
+
+    override val sensorType: Int = Sensor.TYPE_GYROSCOPE
+    override val samplingRate: Int = SensorManager.SENSOR_DELAY_GAME
+
+    override fun formatData(event: SensorEvent): SensorData {
+        return SensorData(
+            type = SensorData.TYPE_GYROSCOPE,
+            values = event.values.clone(),  // [x, y, z] rad/s
+            timestampNs = event.timestamp
+        )
+    }
+}
+```
+
+## 取得できる値
+
+| index | 内容 | 単位 |
+|-------|------|------|
+| 0 | X 軸角速度 | rad/s |
+| 1 | Y 軸角速度 | rad/s |
+| 2 | Z 軸角速度 | rad/s |
+
+## 完了条件
+
+- `GyroscopeCollector.kt` が作成されている
+- `BaseSensorCollector` を継承している
+- ビルドが通ること

--- a/docs/TODO/019-implement-magnetic-field-collector.md
+++ b/docs/TODO/019-implement-magnetic-field-collector.md
@@ -1,0 +1,55 @@
+# 019 MagneticFieldCollector の実装
+
+## 概要
+
+地磁気センサのコレクターを実装する。
+方位角の算出・コンパス機能に使用する。
+
+## 前提
+
+- 017 完了済みであること（`SensorData.TYPE_MAGNETIC_FIELD` が存在する）
+
+## 対象ファイル
+
+新規作成: `sensing/src/main/java/com/example/wearos/sensing/MagneticFieldCollector.kt`
+
+## 実装内容
+
+```kotlin
+package com.example.wearos.sensing
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorManager
+
+class MagneticFieldCollector(
+    context: Context
+) : BaseSensorCollector(context) {
+
+    override val sensorType: Int = Sensor.TYPE_MAGNETIC_FIELD
+    override val samplingRate: Int = SensorManager.SENSOR_DELAY_NORMAL
+
+    override fun formatData(event: SensorEvent): SensorData {
+        return SensorData(
+            type = SensorData.TYPE_MAGNETIC_FIELD,
+            values = event.values.clone(),  // [x, y, z] μT
+            timestampNs = event.timestamp
+        )
+    }
+}
+```
+
+## 取得できる値
+
+| index | 内容 | 単位 |
+|-------|------|------|
+| 0 | X 軸磁束密度 | μT |
+| 1 | Y 軸磁束密度 | μT |
+| 2 | Z 軸磁束密度 | μT |
+
+## 完了条件
+
+- `MagneticFieldCollector.kt` が作成されている
+- `BaseSensorCollector` を継承している
+- ビルドが通ること

--- a/docs/TODO/020-implement-rotation-vector-collector.md
+++ b/docs/TODO/020-implement-rotation-vector-collector.md
@@ -1,0 +1,58 @@
+# 020 RotationVectorCollector の実装
+
+## 概要
+
+回転ベクトルセンサのコレクターを実装する。
+加速度・ジャイロ・地磁気をフュージョンしたソフトウェアセンサで、デバイスの絶対姿勢をクォータニオンで取得できる。
+
+## 前提
+
+- 017 完了済みであること（`SensorData.TYPE_ROTATION_VECTOR` が存在する）
+
+## 対象ファイル
+
+新規作成: `sensing/src/main/java/com/example/wearos/sensing/RotationVectorCollector.kt`
+
+## 実装内容
+
+```kotlin
+package com.example.wearos.sensing
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorManager
+
+class RotationVectorCollector(
+    context: Context
+) : BaseSensorCollector(context) {
+
+    override val sensorType: Int = Sensor.TYPE_ROTATION_VECTOR
+    override val samplingRate: Int = SensorManager.SENSOR_DELAY_GAME
+
+    override fun formatData(event: SensorEvent): SensorData {
+        return SensorData(
+            type = SensorData.TYPE_ROTATION_VECTOR,
+            values = event.values.clone(),  // [x*sin(θ/2), y*sin(θ/2), z*sin(θ/2), cos(θ/2)]
+            timestampNs = event.timestamp
+        )
+    }
+}
+```
+
+## 取得できる値
+
+| index | 内容 |
+|-------|------|
+| 0 | x * sin(θ/2) |
+| 1 | y * sin(θ/2) |
+| 2 | z * sin(θ/2) |
+| 3 | cos(θ/2) ※省略される場合あり |
+
+`SensorManager.getRotationMatrixFromVector()` や `getOrientation()` で方位角・ピッチ・ロールに変換可能。
+
+## 完了条件
+
+- `RotationVectorCollector.kt` が作成されている
+- `BaseSensorCollector` を継承している
+- ビルドが通ること

--- a/docs/TODO/021-implement-step-counter-collector.md
+++ b/docs/TODO/021-implement-step-counter-collector.md
@@ -1,0 +1,60 @@
+# 021 StepCounterCollector の実装
+
+## 概要
+
+歩数カウンターセンサのコレクターを実装する。
+デバイス起動後からの**累積**歩数を返すハードウェアセンサ。
+差分を取ることで区間の歩数を計算できる。
+
+## 前提
+
+- 017 完了済みであること（`SensorData.TYPE_STEP_COUNTER` が存在する）
+
+## 対象ファイル
+
+新規作成: `sensing/src/main/java/com/example/wearos/sensing/StepCounterCollector.kt`
+
+## 実装内容
+
+```kotlin
+package com.example.wearos.sensing
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorManager
+
+class StepCounterCollector(
+    context: Context
+) : BaseSensorCollector(context) {
+
+    override val sensorType: Int = Sensor.TYPE_STEP_COUNTER
+    // STEP_COUNTER はイベント駆動のため SENSOR_DELAY_NORMAL で十分
+    override val samplingRate: Int = SensorManager.SENSOR_DELAY_NORMAL
+
+    override fun formatData(event: SensorEvent): SensorData {
+        return SensorData(
+            type = SensorData.TYPE_STEP_COUNTER,
+            values = event.values.clone(),  // [累積歩数]
+            timestampNs = event.timestamp
+        )
+    }
+}
+```
+
+## 取得できる値
+
+| index | 内容 | 備考 |
+|-------|------|------|
+| 0 | 累積歩数（float） | デバイス再起動でリセット |
+
+## 注意事項
+
+- 値は**累積**なので、アプリ側で前回値との差分を計算すること
+- `SENSOR_DELAY_*` の値はバッチ遅延のヒントにすぎず、実際の配信頻度はシステムが制御する
+
+## 完了条件
+
+- `StepCounterCollector.kt` が作成されている
+- `BaseSensorCollector` を継承している
+- ビルドが通ること

--- a/docs/TODO/022-implement-step-detector-collector.md
+++ b/docs/TODO/022-implement-step-detector-collector.md
@@ -1,0 +1,62 @@
+# 022 StepDetectorCollector の実装
+
+## 概要
+
+歩行検出センサのコレクターを実装する。
+1歩を踏むたびにイベントが発火する（累積ではなくイベント型）。
+リアルタイムな歩行検出・歩行ペース計測に使用する。
+
+## 前提
+
+- 017 完了済みであること（`SensorData.TYPE_STEP_DETECTOR` が存在する）
+
+## 対象ファイル
+
+新規作成: `sensing/src/main/java/com/example/wearos/sensing/StepDetectorCollector.kt`
+
+## 実装内容
+
+```kotlin
+package com.example.wearos.sensing
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorManager
+
+class StepDetectorCollector(
+    context: Context
+) : BaseSensorCollector(context) {
+
+    override val sensorType: Int = Sensor.TYPE_STEP_DETECTOR
+    override val samplingRate: Int = SensorManager.SENSOR_DELAY_NORMAL
+
+    override fun formatData(event: SensorEvent): SensorData {
+        return SensorData(
+            type = SensorData.TYPE_STEP_DETECTOR,
+            values = event.values.clone(),  // [1.0] 常に 1.0（歩行検出イベント）
+            timestampNs = event.timestamp
+        )
+    }
+}
+```
+
+## 取得できる値
+
+| index | 内容 |
+|-------|------|
+| 0 | 常に `1.0`（1歩検出のトリガー） |
+
+## StepCounter との違い
+
+| | StepCounter | StepDetector |
+|---|---|---|
+| 値 | 累積歩数 | 常に 1.0 |
+| 用途 | 総歩数の取得 | リアルタイム歩行検出 |
+| リセット | デバイス再起動時 | なし（イベントのみ） |
+
+## 完了条件
+
+- `StepDetectorCollector.kt` が作成されている
+- `BaseSensorCollector` を継承している
+- ビルドが通ること

--- a/docs/TODO/023-implement-gravity-collector.md
+++ b/docs/TODO/023-implement-gravity-collector.md
@@ -1,0 +1,58 @@
+# 023 GravityCollector の実装
+
+## 概要
+
+重力センサのコレクターを実装する。
+加速度センサから重力成分のみを抽出したソフトウェア合成センサ。
+デバイスの傾き（チルト）検出に使用する。
+
+## 前提
+
+- 017 完了済みであること（`SensorData.TYPE_GRAVITY` が存在する）
+
+## 対象ファイル
+
+新規作成: `sensing/src/main/java/com/example/wearos/sensing/GravityCollector.kt`
+
+## 実装内容
+
+```kotlin
+package com.example.wearos.sensing
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorManager
+
+class GravityCollector(
+    context: Context
+) : BaseSensorCollector(context) {
+
+    override val sensorType: Int = Sensor.TYPE_GRAVITY
+    override val samplingRate: Int = SensorManager.SENSOR_DELAY_GAME
+
+    override fun formatData(event: SensorEvent): SensorData {
+        return SensorData(
+            type = SensorData.TYPE_GRAVITY,
+            values = event.values.clone(),  // [x, y, z] m/s²
+            timestampNs = event.timestamp
+        )
+    }
+}
+```
+
+## 取得できる値
+
+| index | 内容 | 単位 |
+|-------|------|------|
+| 0 | 重力 X 成分 | m/s² |
+| 1 | 重力 Y 成分 | m/s² |
+| 2 | 重力 Z 成分 | m/s² |
+
+静止時、`sqrt(x²+y²+z²) ≈ 9.81 m/s²`
+
+## 完了条件
+
+- `GravityCollector.kt` が作成されている
+- `BaseSensorCollector` を継承している
+- ビルドが通ること

--- a/docs/TODO/024-implement-linear-acceleration-collector.md
+++ b/docs/TODO/024-implement-linear-acceleration-collector.md
@@ -1,0 +1,65 @@
+# 024 LinearAccelerationCollector の実装
+
+## 概要
+
+線形加速度センサのコレクターを実装する。
+加速度センサから重力成分を除いた値を返すソフトウェア合成センサ。
+純粋なデバイスの動き（ユーザーの動作）のみを取得したい場合に使用する。
+
+## 前提
+
+- 017 完了済みであること（`SensorData.TYPE_LINEAR_ACCELERATION` が存在する）
+
+## 対象ファイル
+
+新規作成: `sensing/src/main/java/com/example/wearos/sensing/LinearAccelerationCollector.kt`
+
+## 実装内容
+
+```kotlin
+package com.example.wearos.sensing
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorManager
+
+class LinearAccelerationCollector(
+    context: Context
+) : BaseSensorCollector(context) {
+
+    override val sensorType: Int = Sensor.TYPE_LINEAR_ACCELERATION
+    override val samplingRate: Int = SensorManager.SENSOR_DELAY_GAME
+
+    override fun formatData(event: SensorEvent): SensorData {
+        return SensorData(
+            type = SensorData.TYPE_LINEAR_ACCELERATION,
+            values = event.values.clone(),  // [x, y, z] m/s²（重力除去済み）
+            timestampNs = event.timestamp
+        )
+    }
+}
+```
+
+## 取得できる値
+
+| index | 内容 | 単位 |
+|-------|------|------|
+| 0 | X 軸加速度（重力除去） | m/s² |
+| 1 | Y 軸加速度（重力除去） | m/s² |
+| 2 | Z 軸加速度（重力除去） | m/s² |
+
+静止時は `≈ [0, 0, 0]`
+
+## AccelerometerCollector との違い
+
+| | AccelerometerCollector | LinearAccelerationCollector |
+|---|---|---|
+| 値 | 加速度 + 重力 | 加速度のみ（重力除去） |
+| 静止時 | `[0, 0, 9.81]` など | `[0, 0, 0]` |
+
+## 完了条件
+
+- `LinearAccelerationCollector.kt` が作成されている
+- `BaseSensorCollector` を継承している
+- ビルドが通ること

--- a/docs/TODO/025-implement-pressure-collector.md
+++ b/docs/TODO/025-implement-pressure-collector.md
@@ -1,0 +1,55 @@
+# 025 PressureCollector の実装
+
+## 概要
+
+気圧センサ（バロメーター）のコレクターを実装する。
+大気圧を取得でき、高度変化の推定や天気予測の参考データとして使用できる。
+
+## 前提
+
+- 017 完了済みであること（`SensorData.TYPE_PRESSURE` が存在する）
+
+## 対象ファイル
+
+新規作成: `sensing/src/main/java/com/example/wearos/sensing/PressureCollector.kt`
+
+## 実装内容
+
+```kotlin
+package com.example.wearos.sensing
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorManager
+
+class PressureCollector(
+    context: Context
+) : BaseSensorCollector(context) {
+
+    override val sensorType: Int = Sensor.TYPE_PRESSURE
+    override val samplingRate: Int = SensorManager.SENSOR_DELAY_NORMAL
+
+    override fun formatData(event: SensorEvent): SensorData {
+        return SensorData(
+            type = SensorData.TYPE_PRESSURE,
+            values = event.values.clone(),  // [気圧] hPa
+            timestampNs = event.timestamp
+        )
+    }
+}
+```
+
+## 取得できる値
+
+| index | 内容 | 単位 | 参考値 |
+|-------|------|------|--------|
+| 0 | 大気圧 | hPa | 海面: 1013.25 hPa |
+
+高度の概算: `SensorManager.getAltitude(SensorManager.PRESSURE_STANDARD_ATMOSPHERE, pressure)` が使用可能。
+
+## 完了条件
+
+- `PressureCollector.kt` が作成されている
+- `BaseSensorCollector` を継承している
+- ビルドが通ること

--- a/docs/TODO/026-implement-heart-beat-collector.md
+++ b/docs/TODO/026-implement-heart-beat-collector.md
@@ -1,0 +1,64 @@
+# 026 HeartBeatCollector の実装
+
+## 概要
+
+心拍ビート検出センサのコレクターを実装する。
+1拍ごとにイベントが発火するため、RRI（R-R間隔）の計算や HRV（心拍変動）解析に使用できる。
+
+## 前提
+
+- 017 完了済みであること（`SensorData.TYPE_HEART_BEAT` が存在する）
+
+## 対象ファイル
+
+新規作成: `sensing/src/main/java/com/example/wearos/sensing/HeartBeatCollector.kt`
+
+## 必要なパーミッション
+
+`BODY_SENSORS`（すでに `AndroidManifest.xml` に記載されている前提）
+
+## 実装内容
+
+```kotlin
+package com.example.wearos.sensing
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorManager
+
+class HeartBeatCollector(
+    context: Context
+) : BaseSensorCollector(context) {
+
+    override val sensorType: Int = Sensor.TYPE_HEART_BEAT
+    override val samplingRate: Int = SensorManager.SENSOR_DELAY_NORMAL
+
+    override fun formatData(event: SensorEvent): SensorData {
+        return SensorData(
+            type = SensorData.TYPE_HEART_BEAT,
+            values = event.values.clone(),  // [confidence] 0.0〜1.0
+            timestampNs = event.timestamp
+        )
+    }
+}
+```
+
+## 取得できる値
+
+| index | 内容 | 範囲 |
+|-------|------|------|
+| 0 | ピーク検出の信頼度 | 0.0 〜 1.0 |
+
+- `timestamp` の差分が **RRI（ms）**
+- RRI から HRV（SDNN, RMSSD など）の計算が可能
+
+## 注意事項
+
+- `BODY_SENSORS` パーミッションが実行時に付与されていない場合、`start()` 時にセンサが `null` になり黙ってスキップされる（`BaseSensorCollector` の挙動）
+
+## 完了条件
+
+- `HeartBeatCollector.kt` が作成されている
+- `BaseSensorCollector` を継承している
+- ビルドが通ること

--- a/docs/TODO/027-implement-oxygen-saturation-collector.md
+++ b/docs/TODO/027-implement-oxygen-saturation-collector.md
@@ -1,0 +1,65 @@
+# 027 OxygenSaturationCollector の実装
+
+## 概要
+
+血中酸素飽和度（SpO2）センサのコレクターを実装する。
+Pixel Watch 2 はハードウェア対応済み。
+
+## 前提
+
+- 017 完了済みであること（`SensorData.TYPE_OXYGEN_SATURATION` が存在する）
+
+## 対象ファイル
+
+新規作成: `sensing/src/main/java/com/example/wearos/sensing/OxygenSaturationCollector.kt`
+
+## 必要なパーミッション
+
+`BODY_SENSORS`（すでに `AndroidManifest.xml` に記載されている前提）
+
+## 実装内容
+
+```kotlin
+package com.example.wearos.sensing
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorManager
+
+class OxygenSaturationCollector(
+    context: Context
+) : BaseSensorCollector(context) {
+
+    // TYPE_OXYGEN_SATURATION = 65572 (android.hardware.Sensor の非公開定数)
+    // Android 14 以降は Sensor.TYPE_OXYGEN_SATURATION が利用可能
+    override val sensorType: Int = 65572
+    override val samplingRate: Int = SensorManager.SENSOR_DELAY_NORMAL
+
+    override fun formatData(event: SensorEvent): SensorData {
+        return SensorData(
+            type = SensorData.TYPE_OXYGEN_SATURATION,
+            values = event.values.clone(),  // [SpO2 %]
+            timestampNs = event.timestamp
+        )
+    }
+}
+```
+
+## 取得できる値
+
+| index | 内容 | 単位 | 正常範囲 |
+|-------|------|------|---------|
+| 0 | 血中酸素飽和度 | % | 95〜100% |
+
+## 注意事項
+
+- Android 14 以降で `Sensor.TYPE_OXYGEN_SATURATION` 定数が利用可能になった場合はそちらに切り替える
+- Wear OS はバックグラウンドでの連続計測を制限する場合がある（バッテリー保護のため）
+- `BODY_SENSORS` パーミッションが必要
+
+## 完了条件
+
+- `OxygenSaturationCollector.kt` が作成されている
+- `BaseSensorCollector` を継承している
+- ビルドが通ること

--- a/docs/TODO/028-implement-skin-temperature-collector.md
+++ b/docs/TODO/028-implement-skin-temperature-collector.md
@@ -1,0 +1,69 @@
+# 028 SkinTemperatureCollector の実装
+
+## 概要
+
+皮膚温度センサのコレクターを実装する。
+Pixel Watch 2 固有のセンサで、手首の皮膚表面温度を取得できる。
+発熱検知・睡眠モニタリングなどに使用できる。
+
+## 前提
+
+- 017 完了済みであること（`SensorData.TYPE_SKIN_TEMPERATURE` が存在する）
+
+## 対象ファイル
+
+新規作成: `sensing/src/main/java/com/example/wearos/sensing/SkinTemperatureCollector.kt`
+
+## 必要なパーミッション
+
+`BODY_SENSORS`（すでに `AndroidManifest.xml` に記載されている前提）
+
+## 実装内容
+
+```kotlin
+package com.example.wearos.sensing
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorManager
+
+class SkinTemperatureCollector(
+    context: Context
+) : BaseSensorCollector(context) {
+
+    // TYPE_SKIN_TEMPERATURE = 65572 番台の非公開定数（デバイス依存）
+    // android.hardware.Sensor.TYPE_SKIN_TEMPERATURE が定義されていれば使用する
+    // Pixel Watch 2 では 65536 + 55 = 65591 が該当することが多い（要実機確認）
+    override val sensorType: Int = Sensor.TYPE_AMBIENT_TEMPERATURE  // フォールバック。実機確認後に修正すること
+    override val samplingRate: Int = SensorManager.SENSOR_DELAY_NORMAL
+
+    override fun formatData(event: SensorEvent): SensorData {
+        return SensorData(
+            type = SensorData.TYPE_SKIN_TEMPERATURE,
+            values = event.values.clone(),  // [温度] ℃
+            timestampNs = event.timestamp
+        )
+    }
+}
+```
+
+## 取得できる値
+
+| index | 内容 | 単位 |
+|-------|------|------|
+| 0 | 皮膚表面温度 | ℃ |
+
+## ⚠️ 重要な注意事項
+
+- `TYPE_SKIN_TEMPERATURE` のセンサ定数値は **Pixel Watch 2 の実機で確認**が必要
+- `sensorManager.getSensorList(Sensor.TYPE_ALL)` で全センサを列挙し、`sensor.name` に "skin" や "temperature" を含むものを特定すること
+- デバイスにセンサが存在しない場合、`BaseSensorCollector.start()` は黙ってスキップする（既存の安全設計）
+- `BODY_SENSORS` パーミッションが必要
+
+## 完了条件
+
+- `SkinTemperatureCollector.kt` が作成されている
+- `BaseSensorCollector` を継承している
+- ビルドが通ること
+- 実機でセンサ定数値を確認し、コメントに記録すること

--- a/docs/TODO/029-implement-off-body-detect-collector.md
+++ b/docs/TODO/029-implement-off-body-detect-collector.md
@@ -1,0 +1,60 @@
+# 029 OffBodyDetectCollector の実装
+
+## 概要
+
+装着検出センサのコレクターを実装する。
+ウォッチが手首に装着されているかどうかを検出する。
+非装着時のセンシング停止・アラート通知などに使用できる。
+
+## 前提
+
+- 017 完了済みであること（`SensorData.TYPE_OFF_BODY_DETECT` が存在する）
+
+## 対象ファイル
+
+新規作成: `sensing/src/main/java/com/example/wearos/sensing/OffBodyDetectCollector.kt`
+
+## 実装内容
+
+```kotlin
+package com.example.wearos.sensing
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorManager
+
+class OffBodyDetectCollector(
+    context: Context
+) : BaseSensorCollector(context) {
+
+    override val sensorType: Int = Sensor.TYPE_LOW_LATENCY_OFFBODY_DETECT
+    override val samplingRate: Int = SensorManager.SENSOR_DELAY_NORMAL
+
+    override fun formatData(event: SensorEvent): SensorData {
+        return SensorData(
+            type = SensorData.TYPE_OFF_BODY_DETECT,
+            values = event.values.clone(),  // [0.0 = 装着中, 1.0 = 非装着]
+            timestampNs = event.timestamp
+        )
+    }
+}
+```
+
+## 取得できる値
+
+| index | 値 | 意味 |
+|-------|-----|------|
+| 0 | `0.0` | 装着中（on body） |
+| 0 | `1.0` | 非装着（off body） |
+
+## 特徴
+
+- `LOW_LATENCY` の名前通り、状態変化を低遅延で検出する
+- 連続的にポーリングするのではなく、状態変化時のみイベントが来る
+
+## 完了条件
+
+- `OffBodyDetectCollector.kt` が作成されている
+- `BaseSensorCollector` を継承している
+- ビルドが通ること

--- a/docs/TODO/030-update-usage-docs-new-sensors.md
+++ b/docs/TODO/030-update-usage-docs-new-sensors.md
@@ -1,0 +1,70 @@
+# 030 USAGE.md に新センサの使い方を追記
+
+## 概要
+
+018〜029 の実装完了後、`docs/USAGE.md` に新センサの使い方を追記する。
+**このタスクは 018〜029 がすべて完了してから実施すること。**
+
+## 対象ファイル
+
+`docs/USAGE.md`
+
+## 追記内容
+
+### 追加するセクション（既存の「コード例」セクション内に追記）
+
+#### 利用可能な Collector 一覧テーブル
+
+```markdown
+### 利用可能な Collector 一覧
+
+| クラス | センサ | 取得できる値 | 必要なパーミッション |
+|--------|--------|-------------|-------------------|
+| `AccelerometerCollector` | 加速度センサ | X/Y/Z 加速度 (m/s²) | - |
+| `GyroscopeCollector` | ジャイロスコープ | X/Y/Z 角速度 (rad/s) | - |
+| `MagneticFieldCollector` | 地磁気センサ | X/Y/Z 磁束密度 (μT) | - |
+| `RotationVectorCollector` | 回転ベクトル | クォータニオン | - |
+| `GravityCollector` | 重力センサ | X/Y/Z 重力成分 (m/s²) | - |
+| `LinearAccelerationCollector` | 線形加速度 | X/Y/Z 加速度（重力除去） | - |
+| `StepCounterCollector` | 歩数カウンター | 累積歩数 | - |
+| `StepDetectorCollector` | 歩行検出 | 1歩ごとにイベント | - |
+| `PressureCollector` | 気圧センサ | 大気圧 (hPa) | - |
+| `HeartRateCollector` | 心拍数 | bpm | `BODY_SENSORS` |
+| `HeartBeatCollector` | 心拍ビート | 信頼度 (0〜1) ※RRI算出用 | `BODY_SENSORS` |
+| `OxygenSaturationCollector` | SpO2 | 血中酸素飽和度 (%) | `BODY_SENSORS` |
+| `SkinTemperatureCollector` | 皮膚温度 | 皮膚表面温度 (℃) ※Pixel Watch 2 | `BODY_SENSORS` |
+| `LightCollector` | 照度センサ | 照度 (lux) | - |
+| `OffBodyDetectCollector` | 装着検出 | 0=装着中 / 1=非装着 | - |
+```
+
+#### 全センサを使った例
+
+```kotlin
+pipeline = SensorPipeline(
+    SensorPipelineConfig(
+        collectors = listOf(
+            AccelerometerCollector(this),
+            GyroscopeCollector(this),
+            MagneticFieldCollector(this),
+            RotationVectorCollector(this),
+            GravityCollector(this),
+            LinearAccelerationCollector(this),
+            StepCounterCollector(this),
+            StepDetectorCollector(this),
+            PressureCollector(this),
+            HeartRateCollector(this),
+            HeartBeatCollector(this),
+            OxygenSaturationCollector(this),
+            SkinTemperatureCollector(this),
+            LightCollector(this),
+            OffBodyDetectCollector(this)
+        ),
+        sender = UdpSender("192.168.1.100", 6666)
+    )
+)
+```
+
+## 完了条件
+
+- USAGE.md に上記テーブルとコード例が追記されている
+- 全クラス名・取得値・パーミッションが正確に記載されている

--- a/docs/TODO/README.md
+++ b/docs/TODO/README.md
@@ -22,3 +22,30 @@
 | [016](done/016-gradle-multi-module.md) | Gradle マルチモジュール構成への移行 | ✅ 完了 |
 
 全 16 件完了。初期ライブラリ化対応は完結。
+
+---
+
+## フェーズ2：新センサ追加
+
+| # | issue | 状態 |
+|---|-------|------|
+| [017](017-add-sensor-type-constants.md) | `SensorData` に新センサの TYPE 定数を追加（**先行必須**） | 🔲 未着手 |
+| [018](018-implement-gyroscope-collector.md) | `GyroscopeCollector` の実装 | 🔲 未着手 |
+| [019](019-implement-magnetic-field-collector.md) | `MagneticFieldCollector` の実装 | 🔲 未着手 |
+| [020](020-implement-rotation-vector-collector.md) | `RotationVectorCollector` の実装 | 🔲 未着手 |
+| [021](021-implement-step-counter-collector.md) | `StepCounterCollector` の実装 | 🔲 未着手 |
+| [022](022-implement-step-detector-collector.md) | `StepDetectorCollector` の実装 | 🔲 未着手 |
+| [023](023-implement-gravity-collector.md) | `GravityCollector` の実装 | 🔲 未着手 |
+| [024](024-implement-linear-acceleration-collector.md) | `LinearAccelerationCollector` の実装 | 🔲 未着手 |
+| [025](025-implement-pressure-collector.md) | `PressureCollector` の実装 | 🔲 未着手 |
+| [026](026-implement-heart-beat-collector.md) | `HeartBeatCollector` の実装（RRI/HRV 用） | 🔲 未着手 |
+| [027](027-implement-oxygen-saturation-collector.md) | `OxygenSaturationCollector` の実装（SpO2） | 🔲 未着手 |
+| [028](028-implement-skin-temperature-collector.md) | `SkinTemperatureCollector` の実装（Pixel Watch 2 固有） | 🔲 未着手 |
+| [029](029-implement-off-body-detect-collector.md) | `OffBodyDetectCollector` の実装 | 🔲 未着手 |
+| [030](030-update-usage-docs-new-sensors.md) | `USAGE.md` に新センサの使い方を追記（**018〜029 完了後**） | 🔲 未着手 |
+
+### 並列作業の進め方
+
+1. **017 を単独で先に完了させる**（他全てが `SensorData` の定数に依存するため）
+2. **018〜029 は完全並列**（各自が新規ファイル1つを作成するだけ。コンフリクトなし）
+3. **030 は 018〜029 完了後**にまとめてドキュメント更新


### PR DESCRIPTION
## Summary

- Pixel Watch 2 + Wear OS で取得可能な全センサについて、実装 TODO ドキュメントを追加
- `docs/TODO/` に #017〜#030 の 14 件を作成
- Copilot による並列作業を想定した粒度で設計

## 追加センサ一覧

| # | センサ | クラス名 |
|---|--------|---------|
| 017 | SensorData 定数追加（**先行必須**） | - |
| 018 | ジャイロスコープ | `GyroscopeCollector` |
| 019 | 地磁気 | `MagneticFieldCollector` |
| 020 | 回転ベクトル | `RotationVectorCollector` |
| 021 | 歩数カウンター | `StepCounterCollector` |
| 022 | 歩行検出 | `StepDetectorCollector` |
| 023 | 重力 | `GravityCollector` |
| 024 | 線形加速度 | `LinearAccelerationCollector` |
| 025 | 気圧 | `PressureCollector` |
| 026 | 心拍ビート（RRI/HRV用） | `HeartBeatCollector` |
| 027 | SpO2 | `OxygenSaturationCollector` |
| 028 | 皮膚温度（Pixel Watch 2固有） | `SkinTemperatureCollector` |
| 029 | 装着検出 | `OffBodyDetectCollector` |
| 030 | USAGE.md 更新（**018〜029完了後**） | - |

## 並列作業の進め方

1. **017 を単独で先に完了**（SensorData の定数追加、コンフリクト回避）
2. **018〜029 を Copilot で完全並列**（各タスクが新規ファイル1つのみ）
3. **030 を最後にまとめて**ドキュメント更新

## Test plan

- [ ] 017 完了後、018〜029 の各ファイルが新規作成されること
- [ ] 各 Collector が `BaseSensorCollector` を継承していること
- [ ] ビルドが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)