### PR TITLE
feat: SyncJob の実装 (#53)

### DIFF
--- a/pipeline/src/main/java/com/example/wearos/pipeline/SyncJob.kt
+++ b/pipeline/src/main/java/com/example/wearos/pipeline/SyncJob.kt
@@ -1,0 +1,36 @@
+package com.example.wearos.pipeline
+
+import android.util.Log
+import com.example.wearos.network.DataSender
+import com.example.wearos.storage.SensorDataStore
+
+class SyncJob(
+    private val store: SensorDataStore,
+    private val sender: DataSender,
+    private val chunkSize: Int = DEFAULT_CHUNK_SIZE
+) {
+    fun execute() {
+        val items = store.readAll()
+        if (items.isEmpty()) return
+
+        items.chunked(chunkSize).forEach { chunk ->
+            val ids = chunk.map { it.first }
+            val payload = aggregate(chunk.map { it.second })
+            try {
+                sender.send(payload)
+                store.delete(ids)
+            } catch (e: Exception) {
+                Log.e(TAG, "送信失敗。次回リトライ", e)
+                return
+            }
+        }
+    }
+
+    private fun aggregate(items: List<String>): String =
+        "[${items.joinToString(",")}]"
+
+    companion object {
+        private const val TAG = "SyncJob"
+        private const val DEFAULT_CHUNK_SIZE = 100
+    }
+}


### PR DESCRIPTION
## 概要

Issue #53 の対応。`SyncJob.kt` を新規作成します。

## 変更内容

- `pipeline/src/main/java/com/example/wearos/pipeline/SyncJob.kt` を新規作成

## 実装のポイント

- `store.readAll()` で ID 付きデータを取得
- `chunkSize`（デフォルト 100）件ずつ `aggregate()` で JSON 配列に集約して `sender.send()` で送信
- 送信成功した chunk のみ `store.delete(ids)` で削除
- 送信失敗時はそのチャンク以降を中断し、次回 `execute()` でリトライ可能にする
- `SyncJob` は `Pipeline` を知らない設計（独立して動作）

## Test plan

- [ ] `SyncJob` のビルドが通ること
- [ ] `store.readAll()` が空の場合に早期リターンすること
- [ ] 送信成功時に該当 IDs が削除されること
- [ ] 送信失敗時に削除されず次回リトライできること

https://claude.ai/code/session_01GWZ8XyFAZLf2vaRESBXUx3

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWZ8XyFAZLf2vaRESBXUx3)_