### PR TITLE
feat: SensorPipelineFactory の実装 (#55)

### DIFF
--- a/pipeline/src/main/java/com/example/wearos/pipeline/SensorPipelineFactory.kt
+++ b/pipeline/src/main/java/com/example/wearos/pipeline/SensorPipelineFactory.kt
@@ -1,0 +1,23 @@
+package com.example.wearos.pipeline
+
+import android.content.Context
+import com.example.wearos.network.DataSender
+import com.example.wearos.sensing.BaseSensorCollector
+import com.example.wearos.storage.SensorDataStore
+import com.example.wearos.storage.SQLiteStore
+
+class SensorPipelineFactory(
+    context: Context,
+    val store: SensorDataStore = SQLiteStore(context),
+    val serializer: SensorDataSerializer = JsonSerializer()
+) {
+    fun storeConsumer(): StoreConsumer = StoreConsumer(store, serializer)
+    fun senderConsumer(sender: DataSender): SenderConsumer = SenderConsumer(sender, serializer)
+
+    fun buildPipeline(
+        collectors: List<BaseSensorCollector>,
+        consumers: List<SensorConsumer>
+    ): SensorPipeline = SensorPipeline(collectors, consumers)
+
+    fun buildSyncJob(sender: DataSender): SyncJob = SyncJob(store, sender)
+}


### PR DESCRIPTION
## 概要

Issue #55 の対応。依存インスタンスの生成・保持・組み立てを担う `SensorPipelineFactory` を実装します。

## 変更ファイル

- **新規作成**: `pipeline/src/main/java/com/example/wearos/pipeline/SensorPipelineFactory.kt`

## 実装内容

`store`（`SQLiteStore`）と `serializer`（`JsonSerializer`）を共有インスタンスとして保持し、以下の生成メソッドを提供します：

| メソッド | 返り値 | 説明 |
|---|---|---|
| `storeConsumer()` | `StoreConsumer` | store・serializer 注入済み |
| `senderConsumer(sender)` | `SenderConsumer` | sender・serializer 注入済み |
| `buildPipeline(collectors, consumers)` | `SensorPipeline` | Pipeline を組み立て |
| `buildSyncJob(sender)` | `SyncJob` | store 注入済み SyncJob |

コンストラクタでデフォルト値を持つため、テスト時にモックの `SensorDataStore` / `SensorDataSerializer` を差し込むことも可能です。

## Test plan

- [ ] `SensorPipelineFactory.kt` が作成されている
- [ ] ビルドが通ること

https://claude.ai/code/session_01GWZ8XyFAZLf2vaRESBXUx3

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWZ8XyFAZLf2vaRESBXUx3)_