### PR TITLE
fix: SenderConsumer の executor をコンストラクタ注入可能にする (closes #72)

### DIFF
--- a/pipeline/src/main/java/com/example/wearos/pipeline/SenderConsumer.kt
+++ b/pipeline/src/main/java/com/example/wearos/pipeline/SenderConsumer.kt
@@ -2,15 +2,15 @@ package com.example.wearos.pipeline
 
 import com.example.wearos.network.DataSender
 import com.example.wearos.sensing.SensorData
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 class SenderConsumer(
     private val sender: DataSender,
-    private val serializer: SensorDataSerializer = JsonSerializer()
+    private val serializer: SensorDataSerializer = JsonSerializer(),
+    private val executor: ExecutorService = Executors.newSingleThreadExecutor(),
 ) : SensorConsumer {
-
-    private val executor = Executors.newSingleThreadExecutor()
 
     override fun onData(data: SensorData) {
         val serialized = serializer.serialize(data)


### PR DESCRIPTION
## Summary

- `SenderConsumer` の `executor` をコンストラクタパラメータとして公開し、外部から差し替え可能にした
- デフォルト値は `Executors.newSingleThreadExecutor()` のまま維持し、既存の呼び出し元への影響はない
- `sender.send()` はバックグラウンドスレッド上で実行されるため `NetworkOnMainThreadException` は発生しない

## Test plan

- [ ] センサーデータ取得中に `NetworkOnMainThreadException` が発生しないことを確認
- [ ] `SensorPipeline.stop()` 後に `executor` が正常シャットダウンされることを確認
- [ ] テストコードで `executor` にダイレクトエグゼキュータを渡し、同期的に動作することを確認

Closes #72

https://claude.ai/code/session_01EmTywSEuQEFxfs3EzjrBx9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmTywSEuQEFxfs3EzjrBx9)_