### PR TITLE
feat: JitPack 配布対応（maven-publish 追加）

### DIFF
--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -2,6 +2,7 @@
 plugins {
     alias(libs.plugins.com.android.library)
     alias(libs.plugins.org.jetbrains.kotlin.android)
+    `maven-publish`
 }
 
 android {
@@ -25,4 +26,17 @@ dependencies {
     implementation(libs.core.ktx)
     api(platform(libs.firebase.bom))
     api(libs.firebase.firestore.ktx)
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("release") {
+                from(components["release"])
+                groupId    = "com.github.haruu11113.wearos"
+                artifactId = "network"
+                version    = "1.0.0"
+            }
+        }
+    }
 }

--- a/pipeline/build.gradle.kts
+++ b/pipeline/build.gradle.kts
@@ -2,6 +2,7 @@
 plugins {
     alias(libs.plugins.com.android.library)
     alias(libs.plugins.org.jetbrains.kotlin.android)
+    `maven-publish`
 }
 
 android {
@@ -26,4 +27,17 @@ dependencies {
     api(project(":sensing"))
     api(project(":storage"))
     api(project(":network"))
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("release") {
+                from(components["release"])
+                groupId    = "com.github.haruu11113.wearos"
+                artifactId = "pipeline"
+                version    = "1.0.0"
+            }
+        }
+    }
 }

--- a/sensing/build.gradle.kts
+++ b/sensing/build.gradle.kts
@@ -2,6 +2,7 @@
 plugins {
     alias(libs.plugins.com.android.library)
     alias(libs.plugins.org.jetbrains.kotlin.android)
+    `maven-publish`
 }
 
 android {
@@ -23,4 +24,17 @@ android {
 
 dependencies {
     implementation(libs.core.ktx)
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("release") {
+                from(components["release"])
+                groupId    = "com.github.haruu11113.wearos"
+                artifactId = "sensing"
+                version    = "1.0.0"
+            }
+        }
+    }
 }

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -2,6 +2,7 @@
 plugins {
     alias(libs.plugins.com.android.library)
     alias(libs.plugins.org.jetbrains.kotlin.android)
+    `maven-publish`
 }
 
 android {
@@ -24,5 +25,17 @@ android {
 dependencies {
     implementation(libs.core.ktx)
     implementation(project(":sensing"))
+}
 
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("release") {
+                from(components["release"])
+                groupId    = "com.github.haruu11113.wearos"
+                artifactId = "storage"
+                version    = "1.0.0"
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- `sensing` / `storage` / `network` / `pipeline` の各モジュールに `maven-publish` プラグインと publication 設定を追加
- GitHub に tag を打つだけで JitPack 経由での配布が可能になる

## 利用側での使い方

```kotlin
// settings.gradle.kts
repositories {
    maven { url = uri("https://jitpack.io") }
}

// app/build.gradle.kts
dependencies {
    implementation("com.github.haruu11113.wearos:pipeline:1.0.0")
}
```

## リリース手順（マージ後）

```bash
git tag 1.0.0
git push origin 1.0.0
```

その後 https://jitpack.io/#haruu11113/wearos でビルド確認。

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)